### PR TITLE
fix: Prevent deadlock with database connections

### DIFF
--- a/pg.go
+++ b/pg.go
@@ -44,14 +44,6 @@ func NewPostgresHandlesProvider(config *pgxpool.Config, didsTable string, domain
 }
 
 func (pg *PostgresHandles) GetDecentralizedIDForHandle(ctx context.Context, handle Handle) (DecentralizedID, error) {
-	connection, err := pg.pool.Acquire(ctx)
-
-	defer connection.Release()
-
-	if err != nil {
-		return "", err
-	}
-
 	canProvide, err := pg.CanProvideForDomain(ctx, handle.Domain)
 
 	if err != nil {
@@ -60,6 +52,14 @@ func (pg *PostgresHandles) GetDecentralizedIDForHandle(ctx context.Context, hand
 
 	if !canProvide {
 		return "", &CannotGetHandelsFromDomainError{domain: handle.Domain}
+	}
+
+	connection, err := pg.pool.Acquire(ctx)
+
+	defer connection.Release()
+
+	if err != nil {
+		return "", err
 	}
 
 	var did DecentralizedID


### PR DESCRIPTION
An embarrassing oopsie on my part: a connection was acquired before trying to acquire a second connection, instead of after the connection had been closed.